### PR TITLE
Add alldown command to stop all project containers.

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -197,6 +197,22 @@ use more one docker-compose.yml file.`,
 		},
 	}
 	projectCmd.AddCommand(down)
+
+	alldown := &cobra.Command{
+		Use:   dev.ALLDOWN,
+		Short: "Stop and destroy all " + project.Name + " project containers",
+		Long: `This stops and destroys the container of the same name as the directory in which
+its docker-compose.yml file is placed. It does stop or destroy any containers that
+may have been brought up to support this project.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			dev.RunComposeDown(
+				devConfig.ImagePrefix,
+				project.Config.DockerComposeFilenames,
+			)
+		},
+	}
+	projectCmd.AddCommand(alldown)
+
 }
 
 func addProjects(objMap map[string]dev.Dependency, cmd *cobra.Command, config *config.Dev) error {

--- a/dependency.go
+++ b/dependency.go
@@ -18,6 +18,9 @@ const (
 	// DOWN constant referring to the "down" command of this project which
 	// stops and removes the project container.
 	DOWN = "down"
+	// ALLDOWN constant referring to the "alldown" command of this project which
+	// stops and removes all project containers.
+	ALLDOWN = "alldown"
 	// PS constant referring to the "ps" command of this project which
 	// shows the status of the containers used by the project.
 	PS = "ps"


### PR DESCRIPTION
When I first used the 'down' command, it was surprising how many containers were left running. Later I found out that was by design.

My first thought was to change the 'down' command to do all containers, but that would be especially surprising to folks who run both sweeper and merchant locally, for example. So, maybe let's just add a new command 'alldown' that will also stop shared containers.