### PR TITLE
Add minimum_version entry to config file.

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/mitchellh/go-homedir"
 	log "github.com/sirupsen/logrus"
@@ -232,6 +233,26 @@ func addProjects(objMap map[string]dev.Dependency, cmd *cobra.Command, config *c
 	return nil
 }
 
+func checkMinimumVersion() {
+	mv := AppConfig.MinimumVersion
+	if mv != "" && mv > BuildVersion {
+		fmt.Println()
+		fmt.Println("The config file is requesting version")
+		fmt.Println()
+		fmt.Println("  " + mv)
+		fmt.Println()
+		fmt.Println("but this dev binary is version")
+		fmt.Println()
+		fmt.Println("  " + BuildVersion)
+		fmt.Println()
+		fmt.Println("Please consider updating by running")
+		fmt.Println()
+		fmt.Println("  brew update; brew upgrade wish-dev")
+		fmt.Println()
+		time.Sleep(3 * time.Second)
+	}
+}
+
 func dockerComposeInstalled() bool {
 	userPath := os.Getenv("PATH")
 	if userPath == "" {
@@ -280,6 +301,8 @@ func Initialize() {
 	if viper.GetString("LOGS") == "" {
 		configureLogging(AppConfig.Log.Level)
 	}
+
+	checkMinimumVersion()
 
 	if !dockerComposeInstalled() {
 		log.Fatalf("dev requires docker-compose. See https://docs.docker.com/compose/install/")

--- a/config/config.go
+++ b/config/config.go
@@ -64,6 +64,7 @@ type Dev struct {
 	// found. Note that compose only adds the prefix to local image
 	// builds.
 	ImagePrefix string `mapstructure:"image_prefix"`
+	MinimumVersion string `mapstructure:"minimum_version"`
 
 	// Filesystem to read configuration from
 	fs afero.Fs
@@ -295,6 +296,7 @@ func Merge(target *Dev, source *Dev) error {
 	if isDefaultConfig(target) {
 		// project wide settings are set by the first config listed
 		target.ImagePrefix = source.ImagePrefix
+		target.MinimumVersion = source.MinimumVersion
 		target.Log.Level = source.Log.Level
 		target.Dir = source.Dir
 		target.Filename = source.Filename


### PR DESCRIPTION
 Prompt user to upgrade if version too low.

In the config file .dev.yaml, we will add these contents:

```
# consider the output of 
# $ dev --version
# dev version 
#   Version:	20220516-unreleased
#   Built:	Wed Aug 03 18:00:49 2022
#   Git commit:	70f2336-dirty
#   OS/Arch:	linux/amd64
#
# the version ("20220516-unreleased" in the example above) must be lexically
# greater than the setting below, or dev will prompt the user to upgrade.
minimum_version: "20220811"
```

In this case, because the build version is less than the minimum_version setting, dev will print this message on startup:

```

The config file is requesting version

  20220811

but this dev binary is version

  20220516-unreleased

Please consider updating by running

  brew update; brew upgrade wish-dev

```
and will wait a few seconds before continuing so that the user notices the message.