### PR TITLE
Add download subcommand (can be used instead of build)

### DIFF
--- a/dependency.go
+++ b/dependency.go
@@ -12,11 +12,11 @@ import (
 
 const (
 	// BUILD constant referring to the build command of this project which
-	// builds the project with docker-compose as specified in this tools
+	// builds the project with dobi as specified in this tools
 	// configuration file.
 	BUILD = "build"
 	// DOWNLOAD constant referring to the build command of this project which
-	// builds the project with docker-compose as specified in this tools
+	// downloads the project with dobi as specified in this tools
 	// configuration file.
 	DOWNLOAD = "download"
 	// DOWN constant referring to the "down" command of this project which

--- a/dependency.go
+++ b/dependency.go
@@ -15,6 +15,10 @@ const (
 	// builds the project with docker-compose as specified in this tools
 	// configuration file.
 	BUILD = "build"
+	// DOWNLOAD constant referring to the build command of this project which
+	// builds the project with docker-compose as specified in this tools
+	// configuration file.
+	DOWNLOAD = "download"
 	// DOWN constant referring to the "down" command of this project which
 	// stops and removes the project container.
 	DOWN = "down"


### PR DESCRIPTION
This adds a new 'download' subcommand to dev. The intention is that you can use this to download the images rather than building them. This should save time building, and reduce troubleshooting of build failures.

The way that it works is that the command just calls to dobi to initiate the build, the same as the 'build' subcommand, but it calls dobi to build $CONTAINERNAME_download. The implementation is that there is a small Dockerfile that is just a FROM line that is built, which is essentially the same as downloading.

In the future, I want to add an option to always pull if you want to force a new download. I will need to research how to do this with dobi.
