### PR TITLE
Use docker compose v2

### DIFF
--- a/command.go
+++ b/command.go
@@ -53,7 +53,7 @@ func runCommand(name string, args []string) error {
 // RunDockerCompose runs docker-compose with the specified subcommand and
 // arguments.
 func runDockerCompose(cmd, project string, composePaths []string, args ...string) {
-	cmdLine := []string{"-p", project}
+	cmdLine := []string{"compose", "--compatibility", "-p", project}
 
 	for _, path := range composePaths {
 		cmdLine = append(cmdLine, "-f", path)
@@ -66,7 +66,7 @@ func runDockerCompose(cmd, project string, composePaths []string, args ...string
 		cmdLine = append(cmdLine, arg)
 	}
 
-	runCommand("docker-compose", cmdLine)
+	runCommand("docker", cmdLine)
 }
 
 // RunComposeBuild runs docker-compose build with the specified docker compose

--- a/command_test.go
+++ b/command_test.go
@@ -44,8 +44,8 @@ func TestRunComposeBuild(t *testing.T) {
 		Args         []string
 		Expected     []string
 	}{
-		{"foo", []string{"/foo/bar/baz"}, []string{}, []string{"-p", "foo", "-f", "/foo/bar/baz", "build"}},
-		{"far", []string{"/foo/bar/baz", "/boo/far/faz"}, []string{"--no-skippy"}, []string{"-p", "far", "-f", "/foo/bar/baz", "-f", "/boo/far/faz", "build", "--no-skippy"}},
+		{"foo", []string{"/foo/bar/baz"}, []string{}, []string{"compose", "--compatibility", "-p", "foo", "-f", "/foo/bar/baz", "build"}},
+		{"far", []string{"/foo/bar/baz", "/boo/far/faz"}, []string{"--no-skippy"}, []string{"compose", "--compatibility", "-p", "far", "-f", "/foo/bar/baz", "-f", "/boo/far/faz", "build", "--no-skippy"}},
 	}
 
 	for _, test := range tests {
@@ -54,8 +54,8 @@ func TestRunComposeBuild(t *testing.T) {
 
 		RunComposeBuild(test.Project, test.ComposePaths, test.Args...)
 
-		if tc.Path != "docker-compose" {
-			t.Errorf("Expected path be %s but got %s", "docker-compose", tc.Path)
+		if tc.Path != "docker" {
+			t.Errorf("Expected path be %s but got %s", "docker", tc.Path)
 		}
 
 		expectedArguments := len(test.Expected)
@@ -79,8 +79,8 @@ func TestRunComposeUp(t *testing.T) {
 		Args         []string
 		Expected     []string
 	}{
-		{"foo", []string{"/foo/bar/baz"}, []string{}, []string{"-p", "foo", "-f", "/foo/bar/baz", "up"}},
-		{"far", []string{"/foo/bar/baz", "/boo/far/faz"}, []string{"--no-skippy"}, []string{"-p", "far", "-f", "/foo/bar/baz", "-f", "/boo/far/faz", "up", "--no-skippy"}},
+		{"foo", []string{"/foo/bar/baz"}, []string{}, []string{"compose", "--compatibility", "-p", "foo", "-f", "/foo/bar/baz", "up"}},
+		{"far", []string{"/foo/bar/baz", "/boo/far/faz"}, []string{"--no-skippy"}, []string{"compose", "--compatibility", "-p", "far", "-f", "/foo/bar/baz", "-f", "/boo/far/faz", "up", "--no-skippy"}},
 	}
 
 	for _, test := range tests {
@@ -89,8 +89,8 @@ func TestRunComposeUp(t *testing.T) {
 
 		RunComposeUp(test.Project, test.ComposePaths, test.Args...)
 
-		if tc.Path != "docker-compose" {
-			t.Errorf("Expected path be %s but got %s", "docker-compose", tc.Path)
+		if tc.Path != "docker" {
+			t.Errorf("Expected path be %s but got %s", "docker", tc.Path)
 		}
 
 		expectedArguments := len(test.Expected)
@@ -113,8 +113,8 @@ func TestRunComposePs(t *testing.T) {
 		Args         []string
 		Expected     []string
 	}{
-		{"foo", []string{"/foo/bar/baz"}, []string{}, []string{"-p", "foo", "-f", "/foo/bar/baz", "ps"}},
-		{"far", []string{"/foo/bar/baz", "/boo/far/faz"}, []string{"--no-skippy"}, []string{"-p", "far", "-f", "/foo/bar/baz", "-f", "/boo/far/faz", "ps", "--no-skippy"}},
+		{"foo", []string{"/foo/bar/baz"}, []string{}, []string{"compose", "--compatibility", "-p", "foo", "-f", "/foo/bar/baz", "ps"}},
+		{"far", []string{"/foo/bar/baz", "/boo/far/faz"}, []string{"--no-skippy"}, []string{"compose", "--compatibility", "-p", "far", "-f", "/foo/bar/baz", "-f", "/boo/far/faz", "ps", "--no-skippy"}},
 	}
 
 	for _, test := range tests {
@@ -123,8 +123,8 @@ func TestRunComposePs(t *testing.T) {
 
 		RunComposePs(test.Project, test.ComposePaths, test.Args...)
 
-		if tc.Path != "docker-compose" {
-			t.Errorf("Expected path be %s but got %s", "docker-compose", tc.Path)
+		if tc.Path != "docker" {
+			t.Errorf("Expected path be %s but got %s", "docker", tc.Path)
 		}
 
 		expectedArguments := len(test.Expected)
@@ -147,8 +147,8 @@ func TestRunComposeLogs(t *testing.T) {
 		Args         []string
 		Expected     []string
 	}{
-		{"foo", []string{"/foo/bar/baz"}, []string{}, []string{"-p", "foo", "-f", "/foo/bar/baz", "logs"}},
-		{"far", []string{"/foo/bar/baz", "/boo/far/faz"}, []string{"--no-skippy"}, []string{"-p", "far", "-f", "/foo/bar/baz", "-f", "/boo/far/faz", "logs", "--no-skippy"}},
+		{"foo", []string{"/foo/bar/baz"}, []string{}, []string{"compose", "--compatibility", "-p", "foo", "-f", "/foo/bar/baz", "logs"}},
+		{"far", []string{"/foo/bar/baz", "/boo/far/faz"}, []string{"--no-skippy"}, []string{"compose", "--compatibility", "-p", "far", "-f", "/foo/bar/baz", "-f", "/boo/far/faz", "logs", "--no-skippy"}},
 	}
 
 	for _, test := range tests {
@@ -157,8 +157,8 @@ func TestRunComposeLogs(t *testing.T) {
 
 		RunComposeLogs(test.Project, test.ComposePaths, test.Args...)
 
-		if tc.Path != "docker-compose" {
-			t.Errorf("Expected path be %s but got %s", "docker-compose", tc.Path)
+		if tc.Path != "docker" {
+			t.Errorf("Expected path be %s but got %s", "docker", tc.Path)
 		}
 
 		expectedArguments := len(test.Expected)
@@ -182,8 +182,8 @@ func TestRunComposeDown(t *testing.T) {
 		Args         []string
 		Expected     []string
 	}{
-		{"foo", []string{"/foo/bar/baz"}, []string{}, []string{"-p", "foo", "-f", "/foo/bar/baz", "down"}},
-		{"far", []string{"/foo/bar/baz", "/boo/far/faz"}, []string{"--no-skippy"}, []string{"-p", "far", "-f", "/foo/bar/baz", "-f", "/boo/far/faz", "down", "--no-skippy"}},
+		{"foo", []string{"/foo/bar/baz"}, []string{}, []string{"compose", "--compatibility", "-p", "foo", "-f", "/foo/bar/baz", "down"}},
+		{"far", []string{"/foo/bar/baz", "/boo/far/faz"}, []string{"--no-skippy"}, []string{"compose", "--compatibility", "-p", "far", "-f", "/foo/bar/baz", "-f", "/boo/far/faz", "down", "--no-skippy"}},
 	}
 
 	for _, test := range tests {
@@ -192,8 +192,8 @@ func TestRunComposeDown(t *testing.T) {
 
 		RunComposeDown(test.Project, test.ComposePaths, test.Args...)
 
-		if tc.Path != "docker-compose" {
-			t.Errorf("Expected path be %s but got %s", "docker-compose", tc.Path)
+		if tc.Path != "docker" {
+			t.Errorf("Expected path be %s but got %s", "docker", tc.Path)
 		}
 
 		expectedArguments := len(test.Expected)

--- a/project.go
+++ b/project.go
@@ -51,7 +51,7 @@ func (p *Project) GetName() string {
 
 // Up brings up the specified project container with its dependencies.
 func (p *Project) Up(appConfig *c.Dev) {
-	RunComposeUp(appConfig.ImagePrefix, p.Config.DockerComposeFilenames, "-d")
+	RunComposeUp(appConfig.ImagePrefix, p.Config.DockerComposeFilenames, "-d", "--no-build")
 }
 
 // UpFollowProjectLogs brings up the specified project with its dependencies


### PR DESCRIPTION
This will benefit users because it will always use docker compose v2. Previously it would just call "docker-compose" which could be either version. Now it will call "docker compose" which is always v2. Also we use the --compatibility flag to avoid problems with the v1 -> v2 migration. Without this flag, sometimes images with underscores in their name would not be found.