### PR TITLE
Add project_command_aliases config option.

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -260,6 +260,19 @@ may have been brought up to support this project.`,
 	}
 	projectCmd.AddCommand(alldown)
 
+	for source, alias := range devConfig.ProjectCommandAliases {
+		alias := &cobra.Command{
+			Use:   source,
+			Short: alias.ShortDescription,
+			Long:  alias.LongDescription,
+			Run: func(cmd *cobra.Command, args []string) {
+				all := append([]string{alias.Target}, args...)
+				project.Shell(AppConfig, all)
+			},
+		}
+		projectCmd.AddCommand(alias)
+	}
+
 }
 
 func addProjects(objMap map[string]dev.Dependency, cmd *cobra.Command, config *config.Dev) error {

--- a/config/config.go
+++ b/config/config.go
@@ -63,8 +63,9 @@ type Dev struct {
 	// file is located or the directory or the docker-compose.yml if one is
 	// found. Note that compose only adds the prefix to local image
 	// builds.
-	ImagePrefix    string `mapstructure:"image_prefix"`
-	MinimumVersion string `mapstructure:"minimum_version"`
+	ImagePrefix           string                          `mapstructure:"image_prefix"`
+	MinimumVersion        string                          `mapstructure:"minimum_version"`
+	ProjectCommandAliases map[string]*ProjectCommandAlias `mapstructure:"project_command_aliases"`
 
 	// Filesystem to read configuration from
 	fs afero.Fs
@@ -120,6 +121,13 @@ type Registry struct {
 	// if login or connection fails, should dev continue with command or
 	// fail hard.  Default is True
 	ContinueOnFailure bool `mapstructure:"continue_on_failure"`
+}
+
+// ProjectCommandAlias represents an alias defined in .dev.yaml
+type ProjectCommandAlias struct {
+	Target           string `mapstructure:"target"`
+	ShortDescription string `mapstructure:"short_description"`
+	LongDescription  string `mapstructure:"long_description"`
 }
 
 // NewConfig structs the default configuration structure for dev driven
@@ -302,6 +310,7 @@ func Merge(target *Dev, source *Dev) error {
 		target.Log.Level = source.Log.Level
 		target.Dir = source.Dir
 		target.Filename = source.Filename
+		target.ProjectCommandAliases = source.ProjectCommandAliases
 
 	} else if source.ImagePrefix != target.ImagePrefix {
 		// Not sure I like forcing this.. but if users switch back and forth


### PR DESCRIPTION
This adds a new feature where aliases can be defined in the .dev.yaml config file. These project commands will run commands inside the container.